### PR TITLE
fix checkout latest jdk action

### DIFF
--- a/.github/workflows/maven-service-build.yml
+++ b/.github/workflows/maven-service-build.yml
@@ -41,6 +41,8 @@ jobs:
           ref: v1.0.22
           token: ${{ secrets.action-fetch-token }}
           path: .github/actions/action-jdk-build
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Run Build Java
         uses: ./.github/actions/action-jdk-build

--- a/.github/workflows/maven-service-deploy.yml
+++ b/.github/workflows/maven-service-deploy.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Checkout GitHub Action JDK Build Repo
-        uses: @v4
+        uses: actions/checkout@v4
         with:
           repository: empayre/action-jdk-build
           ref: v1.0.18

--- a/.github/workflows/maven-service-deploy.yml
+++ b/.github/workflows/maven-service-deploy.yml
@@ -42,12 +42,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Checkout GitHub Action JDK Build Repo
-        uses: actions/checkout@v4
+        uses: @v4
         with:
           repository: empayre/action-jdk-build
           ref: v1.0.18
           token: ${{ secrets.action-fetch-token }}
           path: .github/actions/action-jdk-build
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Checkout GitHub Action Deploy Docker Repo
         uses: actions/checkout@v4

--- a/.github/workflows/maven-service-deploy.yml
+++ b/.github/workflows/maven-service-deploy.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: empayre/action-jdk-build
-          ref: v1.0.18
+          ref: v1.0.22
           token: ${{ secrets.action-fetch-token }}
           path: .github/actions/action-jdk-build
           fetch-depth: 0


### PR DESCRIPTION
При сборке проектов подхватывает устаревшую версию action-jdk-build, без fetch-depth настройки собирается не все теги и коммиты, поэтому может игнорировать ref настройку и брать что попало. Но это мое предположение, по крайней мере из [логов сборки](https://github.com/empayre/all-in-gateway-api/actions/runs/13289391241/job/37106001496) видно, что берет старую версию v1.0.21, а надо v1.0.22.